### PR TITLE
Add ability to pass an element as container

### DIFF
--- a/lib/videojs-Background.js
+++ b/lib/videojs-Background.js
@@ -25,7 +25,7 @@
         player = this,
         videoEl = d.getElementById(player.id() + '_' + settings.mediaType + '_api');
 
-      if(settings.container !== _body) {
+      if(settings.container !== _body && 'string' === typeof settings.container ) {
         settings.container = d.getElementById(settings.container);
       }
 


### PR DESCRIPTION
What do you think of this change? I have a situation where I have id-less containers and would like to pass an already selected element in as container. Something like: 

``` javascript
module.exports = function (videos) {
    videos.each(function () {
        var video     = $(this);
        var container = video.parent();

        new window.videojs(this, {
            techOrder: ['youtube'],
            src: video.data('video-url'),
            controls: false,
            autoplay: true,
            preload: 'auto',
            loop: true
        }).Background({
            mediaType: 'youtube',
            container: container[0]  // <===
        });
    });
};
```
