### PR TITLE
fix module not found

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   "peerDependencies": {
     "video.js": "^4.12.5"
   },
-  "main": "dist/videojs-background.js",
+  "main": "lib/videojs-Background.js",
   "directories": {
     "test": "test"
   },


### PR DESCRIPTION
`require('videojs-background')` returned module not found with previous config
