### PR TITLE
preserves any functions previously set to window.onresize

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 *.log
 node_modules/
 *~
+bower_components/

--- a/lib/videojs-Background.js
+++ b/lib/videojs-Background.js
@@ -47,8 +47,12 @@
         updateSize(settings, player);
       });
 
+      var oldResize = window.onresize;
       window.onresize = function(){
         updateSize(settings, player);
+        if (typeof oldResize === 'function') {
+          oldResize();
+        }
       };
   };
 

--- a/test/index.html
+++ b/test/index.html
@@ -14,7 +14,7 @@
       ok(true, 'everything is swell');
     });
   </script>
-  <script src="../node_modules/video.js/dist/video-js/video.js"></script>
+  <script src="../node_modules/video.js/dist/video.js"></script>
   <script src="../lib/videojs-Background.js"></script>
   <script src="videojs-Background.test.js"></script>
 </body>


### PR DESCRIPTION
Hi, I ran into an issue trying to apply multiple background videos on a single page. The initialization worked fine, but on window resizes, only the last video would update it's size. I traced the problem down to the window.onresize call that you were making in your plugin. This update should fix that to allow proper support for multiple videos.
