### PR TITLE
npm fix for bad path in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "grunt-contrib-watch": "^0.4",
     "qunitjs": "^1.12"
   },
-  "main": "dist/videojs-background.js",
+  "main": "./lib/videojs-Background.js",
   "directories": {
     "test": "test"
   },


### PR DESCRIPTION
The path in the `package.json` file is not correct. The change below fixes errors with using

`require("videojs-Background");`

This fixed things for me using Browserify. I suspect you could close #17 after merging this small change.